### PR TITLE
Increase performance with new fingerprint implementation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: morgancpp
-Version: 0.1.0
+Version: 0.1.1
 Date: 2019-12-08
 License: MIT
 Title: Morgan fingerprints in C++
@@ -11,5 +11,5 @@ Encoding: UTF-8
 LinkingTo: Rcpp
 Imports: Rcpp
 RoxygenNote: 7.0.0
-Suggests: 
+Suggests:
     testthat (>= 2.1.0)

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,1 +1,1 @@
-PKG_CXXFLAGS=-O2 -mpopcnt -mavx -mtune=haswell
+PKG_CXXFLAGS=--std=c++14 -O2 -mpopcnt -mavx -mtune=haswell

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,1 @@
+PKG_CXXFLAGS=-O2 -mpopcnt -mavx -mtune=haswell

--- a/src/morgan.cpp
+++ b/src/morgan.cpp
@@ -36,8 +36,9 @@ Fingerprint hex2fp(const std::string& hex) {
   }
   // Convert hex to raw bytes
   std::string raw(256, '\0');
-  for (int i = 0; i < hex.length(); i += 2) {
-    raw[i/2] = parse_hex_char(hex[i]) | (parse_hex_char(hex[i+1]) << 4);
+  auto hi = std::cbegin(hex);
+  for (auto& ri : raw) {
+    ri = parse_hex_char(*hi++) | (parse_hex_char(*hi++) << 4);
   }
   return raw2fp(raw);
 }
@@ -89,9 +90,8 @@ public:
 
   // Constructor accepts a character vector of hex strings
   MorganFPS(const std::vector<std::string>& vhx) {
-    for (int i = 0; i < vhx.size(); ++i) {
-      Fingerprint fp = hex2fp(vhx[i]);
-      fps.push_back(fp);
+    for (auto&& hex : vhx) {
+      fps.push_back(hex2fp(hex));
     }
   }
 
@@ -109,9 +109,10 @@ public:
     if (i <= 0 || i > fps.size()) {
       ::Rf_error("Index out of range");
     }
-    std::vector<double> res(fps.size());
-    for (int ii = 0; ii < fps.size(); ++ii) {
-      res[ii] = jaccard_fp(fps[i-1], fps[ii]);
+    std::vector<double> res;
+    res.reserve(fps.size());
+    for (auto&& fp : fps) {
+      res.push_back(jaccard_fp(fps[i-1], fp));
     }
     return res;
   }
@@ -119,10 +120,11 @@ public:
   // Tanimoto similarity of an external drug to every other drug
   //   in the collection
   std::vector<double> tanimoto_ext(const std::string& other) {
-    Fingerprint fp = hex2fp(other);
-    std::vector<double> res(fps.size());
-    for (int ii = 0; ii < fps.size(); ++ii) {
-      res[ii] = jaccard_fp(fp, fps[ii]);
+    Fingerprint fp_other = hex2fp(other);
+    std::vector<double> res;
+    res.reserve(fps.size());
+    for (auto&& fp : fps) {
+      res.push_back(jaccard_fp(fp_other, fp));
     }
     return res;
   }

--- a/src/morgan.cpp
+++ b/src/morgan.cpp
@@ -68,8 +68,8 @@ double jaccard_fp(const Fingerprint& f1, const Fingerprint& f2) {
 //' @export
 // [[Rcpp::export]]
 double tanimoto(const std::string& s1, const std::string& s2) {
-  Fingerprint fp1 = hex2fp(s1);
-  Fingerprint fp2 = hex2fp(s2);
+  const Fingerprint& fp1 = hex2fp(s1);
+  const Fingerprint& fp2 = hex2fp(s2);
   return jaccard_fp(fp1, fp2);
 }
 
@@ -98,21 +98,16 @@ public:
   // Tanimoto similarity between drugs i and j
   // Adjust for 0-based indexing
   double tanimoto(int i, int j) {
-    if (i <= 0 || j <= 0 || i > fps.size() || j > fps.size()) {
-      ::Rf_error("Index out of range");
-    }
-    return jaccard_fp(fps[i-1], fps[j-1]);
+    return jaccard_fp(fps.at(i-1), fps.at(j-1));
   }
 
   // Tanimoto similarity of drug i to every other drug
   std::vector<double> tanimoto_all(int i) {
-    if (i <= 0 || i > fps.size()) {
-      ::Rf_error("Index out of range");
-    }
+    const Fingerprint& fp_other = fps.at(i-1);
     std::vector<double> res;
     res.reserve(fps.size());
     for (auto&& fp : fps) {
-      res.push_back(jaccard_fp(fps[i-1], fp));
+      res.push_back(jaccard_fp(fp, fp_other));
     }
     return res;
   }
@@ -120,11 +115,11 @@ public:
   // Tanimoto similarity of an external drug to every other drug
   //   in the collection
   std::vector<double> tanimoto_ext(const std::string& other) {
-    Fingerprint fp_other = hex2fp(other);
+    const Fingerprint& fp_other = hex2fp(other);
     std::vector<double> res;
     res.reserve(fps.size());
     for (auto&& fp : fps) {
-      res.push_back(jaccard_fp(fp_other, fp));
+      res.push_back(jaccard_fp(fp, fp_other));
     }
     return res;
   }

--- a/tests/testthat/test-morgancpp.R
+++ b/tests/testthat/test-morgancpp.R
@@ -49,7 +49,7 @@ test_that("Collections can be queried for full similarity profiles", {
     v0 <- sapply( 1:100, function(i) m$tanimoto(1,i) )
     v1 <- m$tanimoto_all(1)
     v2 <- m$tanimoto_ext(v[1])
-    
+
     expect_length( v1, 100 )
     expect_length( v2, 100 )
     expect_identical( v0, v1 )
@@ -61,19 +61,19 @@ test_that("Collection indexing is 1-based", {
     m <- MorganFPS$new(v)
 
     ## Pair-wise function
-    expect_error( m$tanimoto(0,1), "Index out of range" )
-    expect_error( m$tanimoto(1,0), "Index out of range" )
-    expect_error( m$tanimoto(-1,1), "Index out of range" )
-    expect_error( m$tanimoto(1,-1), "Index out of range" )
-    expect_error( m$tanimoto(1001,1), "Index out of range" )
-    expect_error( m$tanimoto(1,1001), "Index out of range" )
+    expect_error( m$tanimoto(0,1), class = "std::out_of_range" )
+    expect_error( m$tanimoto(1,0), class = "std::out_of_range" )
+    expect_error( m$tanimoto(-1,1), class = "std::out_of_range" )
+    expect_error( m$tanimoto(1,-1), class = "std::out_of_range" )
+    expect_error( m$tanimoto(1001,1), class = "std::out_of_range" )
+    expect_error( m$tanimoto(1,1001), class = "std::out_of_range" )
 
     expect_identical( m$tanimoto(1000,1000), 1 )
 
     ## Full-profile function
-    expect_error( m$tanimoto_all(-1), "Index out of range" )
-    expect_error( m$tanimoto_all(0), "Index out of range" )
-    expect_error( m$tanimoto_all(1001), "Index out of range" )
+    expect_error( m$tanimoto_all(-1), class = "std::out_of_range" )
+    expect_error( m$tanimoto_all(0), class = "std::out_of_range" )
+    expect_error( m$tanimoto_all(1001), class = "std::out_of_range" )
 
     expect_length( m$tanimoto_all(1000), 1000 )
 })

--- a/tests/testthat/test-morgancpp.R
+++ b/tests/testthat/test-morgancpp.R
@@ -27,7 +27,7 @@ test_that("Hex strings have to be of length 512", {
 test_that("New collections can be instatiated from hex strings", {
     v <- load_example1(1000)
     m <- MorganFPS$new(v)
-    expect_identical( m$size(), 256000 )
+    expect_equal( m$size(), 256000 )
 })
 
 test_that("Collections can be queried for pairwise similarities", {


### PR DESCRIPTION
Now fingerprints are stored as an array of integers rather than a bitset.
The array can be more efficiently constructed, and our own jaccard
implementation appears to be much faster than using bitset's operator
overloads and ::count.

The code was also refactored to use iterators and range-based for loops where possible.